### PR TITLE
Change activerecord gemspec dependency

### DIFF
--- a/acts_as.gemspec
+++ b/acts_as.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency 'rspec', '< 3.0'
+  spec.add_development_dependency 'rspec', '< 2.99'
   spec.add_development_dependency 'sqlite3'
 
-  spec.add_dependency 'activerecord', '4.0.9'
+  spec.add_dependency 'activerecord', '< 4.2'
 end

--- a/lib/acts_as/version.rb
+++ b/lib/acts_as/version.rb
@@ -1,3 +1,3 @@
 module ActsAs
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end

--- a/spec/acts_as_spec.rb
+++ b/spec/acts_as_spec.rb
@@ -6,11 +6,11 @@ class User < ActiveRecord::Base
 end
 
 class RebelProfile < ActiveRecord::Base
-  has_one :rebel
+  has_one :rebel, foreign_key: :profile_id
 end
 
 class ImperialProfile < ActiveRecord::Base
-  has_one :imperial
+  has_one :imperial, foreign_key: :profile_id
 end
 
 class Clan < ActiveRecord::Base
@@ -41,8 +41,7 @@ end
 
 describe ActsAs do
 
-  let(:rebel) { Rebel.create(name: "Leia", clan_name: "Organa") }
-  subject { rebel }
+  subject(:rebel) { Rebel.create(name: "Leia", clan_name: "Organa") }
 
   it 'raises exception for non-ActiveRecord::Base extensions' do
     expect {


### PR DESCRIPTION
It was locking to 4.0.9 which means we actually downgraded upon upgrading Rails.
Bump version to 0.6.2

Add foreign_key attribute to test associations.
Our app always seems to define the foreign_key, so I'm continuing that behavior here.