### PR TITLE
Update for Rails 4.2

### DIFF
--- a/acts_as.gemspec
+++ b/acts_as.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '< 2.99'
   spec.add_development_dependency 'sqlite3'
 
-  spec.add_dependency 'activerecord', '< 4.2'
+  spec.add_dependency 'activerecord', '< 4.3'
 end

--- a/lib/acts_as/version.rb
+++ b/lib/acts_as/version.rb
@@ -1,3 +1,3 @@
 module ActsAs
-  VERSION = "0.6.2"
+  VERSION = "0.6.3"
 end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -9,27 +9,27 @@ ActiveRecord::Migration.create_table :users do |t|
   t.string :type
   t.integer :clan_id
   t.integer :profile_id
-  t.timestamps
+  t.timestamps null: false
 end
 
 ActiveRecord::Migration.create_table :rebel_profiles do |t|
   t.string :serial_data
-  t.timestamps
+  t.timestamps null: false
 end
 
 ActiveRecord::Migration.create_table :imperial_profiles do |t|
   t.string :analog_data
-  t.timestamps
+  t.timestamps null: false
 end
 
 ActiveRecord::Migration.create_table :clans do |t|
   t.string :name
   t.integer :strength, default: 50
   t.boolean :cool
-  t.timestamps
+  t.timestamps null: false
 end
 
 ActiveRecord::Migration.create_table :x_wings do |t|
   t.integer :rebel_id
-  t.timestamps
+  t.timestamps null: false
 end


### PR DESCRIPTION
Set new AR gemspec limit to 4.3.
Set "null: false" on timestamps to avoid deprecation warnings.
Bump version to 0.6.3.
[#81515520]