### PR TITLE
explicit delegations

### DIFF
--- a/acts_as.gemspec
+++ b/acts_as.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec', '< 2.99'
   spec.add_development_dependency 'sqlite3'

--- a/lib/acts_as.rb
+++ b/lib/acts_as.rb
@@ -107,11 +107,13 @@ module ActsAs
     end
 
     def delegations(association_class, delegated_names)
-      delegated_bools      = boolean_columns(association_class)  & delegated_names
-      delegated_columns    = association_class.column_names      & delegated_names
-      delegated_methods    = delegated_names - delegated_bools - delegated_columns
-      delegated_bools      = delegated_bools    + delegated_bools.map     { |field| "#{field}?" }
-      delegated_columns    = delegated_columns  + delegated_columns.map   { |field| "#{field}=" } + delegated_columns.map  { |field| "#{field}_was" }
+      delegated_reflections = association_class.reflections.keys  & delegated_names
+      delegated_bools       = boolean_columns(association_class)  & delegated_names
+      delegated_columns     = association_class.column_names      & delegated_names
+      delegated_methods     = delegated_names - delegated_bools - delegated_columns - delegated_reflections
+      delegated_bools       = delegated_bools    + delegated_bools.map     { |field| "#{field}?" }
+      delegated_columns     = delegated_columns  + delegated_reflections
+      delegated_columns     = delegated_columns  + delegated_columns.map   { |field| "#{field}=" } + delegated_columns.map  { |field| "#{field}_was" }
 
       delegated_bools + delegated_methods + delegated_columns
     end

--- a/spec/acts_as_spec.rb
+++ b/spec/acts_as_spec.rb
@@ -27,16 +27,16 @@ end
 
 class Rebel < User
   acts_as :profile, class_name: 'RebelProfile'
-  acts_as :clan, prefix: %w( name ), with: %w( delegate_at_will )
+  acts_as :clan, prefix: %w( name ), with: %w( delegate_at_will strength cool )
 end
 
 class RebelWithStrongParams < User
   include ActiveModel::ForbiddenAttributesProtection
-  acts_as :clan, prefix: %w( name ), with: %w( delegate_at_will )
+  acts_as :clan, prefix: %w( name ), with: %w( delegate_at_will cool )
 end
 
 class Imperial < User
-  acts_as :profile, class_name: 'ImperialProfile'
+  acts_as :profile, class_name: 'ImperialProfile', with: %w( analog_data )
 end
 
 describe ActsAs do
@@ -115,7 +115,7 @@ describe ActsAs do
   end
 
   describe 'boolean helpers' do
-    it { should respond_to(:cool?)}
+    it      { should respond_to(:cool?) }
     specify { rebel.should_not be_cool }
   end
 

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -14,6 +14,7 @@ end
 
 ActiveRecord::Migration.create_table :rebel_profiles do |t|
   t.string :serial_data
+  t.string :validated_attr
   t.timestamps null: false
 end
 


### PR DESCRIPTION
refactored out use of method_missing

moved to explicit delegations with proper prefixing

removed some of the magic, but retained all the features

now all attrs/methods you want to access through association must be whitelisted