### PR TITLE
Remove unncessary line that breaks soft_deletion

### DIFF
--- a/lib/acts_as.rb
+++ b/lib/acts_as.rb
@@ -58,7 +58,6 @@ module ActsAs
     end
 
     def where(opts = :chain, *rest)
-      return self if opts.blank?
       relation = super
       #TODO support nested attribute joins like Guns.where(rebels: {strength: 10}))
       # for now, only first level joins will happen automagically

--- a/lib/acts_as/version.rb
+++ b/lib/acts_as/version.rb
@@ -1,3 +1,3 @@
 module ActsAs
-  VERSION = "0.6.4"
+  VERSION = "0.6.5"
 end


### PR DESCRIPTION
I think this line is vestigial from before the default assignment was added.
In any event, it was breaking things in a particular usage of the new soft_deletion gem.